### PR TITLE
remove unreachable surrogate-pair alternative from Unescaped

### DIFF
--- a/lib/parser/querypack.pegjs
+++ b/lib/parser/querypack.pegjs
@@ -82,8 +82,9 @@ Quote          = "'"
  * \x3b = ";"
  * \x5c = "\"
  */
+// Matches one UTF-16 code unit. The range spans the surrogate blocks, so a character
+// beyond the BMP matches as its two surrogates and is rejoined by the String rule.
 Unescaped      = [\x00-\x2b\x2d-\x3a\x3c-\x5b\x5d-\uFFFF]
-               / [\uD800-\uDBFF][\uDC00-\uDFFF]  // Surrogate pairs for characters beyond BMP
 
 Letter        = [a-z]
 Digit1_9      = [1-9]


### PR DESCRIPTION
### Summary

The second `Unescaped` alternative added in #30 is unreachable. The first alternative's range
already spans the surrogate blocks, and PEG choice is ordered, so a lone high surrogate always
matches there first.

```
Unescaped = [\x00-\x2b\x2d-\x3a\x3c-\x5b\x5d-\uFFFF]   <- includes D800-DFFF
          / [\uD800-\uDBFF][\uDC00-\uDFFF]             <- never reached
```

Astral characters still decode correctly: they are consumed as two separate single-code-unit
matches, and the `String` rule's `chars.join("")` rejoins them into the original text. So this is a
no-op removal rather than a behavior change.

### Verification

Instrumenting the two alternatives with distinguishable actions on peggy 4.2 and parsing `"a世🌍"`:

| grammar | matches |
| --- | --- |
| as on `main` | `["alt1","alt1","alt1","alt1"]` -- alt 2 never fires |
| alt 1 alone | `["alt1","alt1","alt1","alt1"]` -- identical |
| alt 2 moved first | `["alt1","alt1","alt2"]` -- only then does it fire |

`npm test` is 222 passed before and after, including the `bel/7/non-ascii-test` example from #30.
Lowering the ceiling to `\uD7FF` fails exactly that one test, which confirms the astral coverage
comes from the range itself.

### Why bother with a no-op

The line costs nothing at runtime, but its comment says the opposite of what the grammar does, and
that matters when the grammar is ported. We maintain a Go port generated with
[pigeon](https://github.com/mna/pigeon), which matches runes rather than UTF-16 code units; there
`\uD800` is not a legal rune literal and the grammar fails to compile outright. Swapping the dead
alternative for a note on the code-unit semantics keeps the useful signal.

Happy to drop the comment and make this a pure deletion if you would rather keep the diff minimal.
